### PR TITLE
let user decide if 'run all' behaviour should be enabled

### DIFF
--- a/lib/guard/reek.rb
+++ b/lib/guard/reek.rb
@@ -11,7 +11,7 @@ module Guard
 
     def initialize(watchers = [], options = {})
       super
-      @options = options
+      @options = { run_all: true }.merge options
       @files = Dir["**/*"]
       @files.select! do |file|
         watchers.reduce(false) { |res, watcher| res || watcher.match(file) }
@@ -24,8 +24,12 @@ module Guard
     end
 
     def run_all
-      UI.info('Guard::Reek is running on all files')
-      self.class.reek @files
+      if @options[:run_all]
+        UI.info('Guard::Reek is running on all files')
+        self.class.reek @files
+      else
+        UI.info('Guard::Reek is not allowed to run on all files')
+      end
     end
 
     def run_on_modifications path

--- a/spec/guard/reek_spec.rb
+++ b/spec/guard/reek_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Guard::Reek do
   subject { reek }
-  let(:guard) { described_class.new }
+  let(:guard) { described_class.new [], options }
+  let(:options) { {} }
 
   before do
     Guard::Notifier.stub :notify
@@ -28,6 +29,16 @@ describe Guard::Reek do
       described_class.should_receive(:reek).with([])
 
       run_all
+    end
+
+    describe "with run_all disabled" do
+      let(:options) { { run_all: false } }
+
+      it "does not run reek" do
+        described_class.should_not_receive(:reek)
+
+        run_all
+      end
     end
   end
 


### PR DESCRIPTION
I'm adding guard-reek to a large project that has a lot of reek failures. Running reek from the terminal grinds for a long time, so I want to control guard-reek so it only ever runs on changed files and never runs on the entire project.
