### PR TITLE
Resolved deprecation warnings of Guard 2.0 

### DIFF
--- a/lib/guard/reek.rb
+++ b/lib/guard/reek.rb
@@ -1,18 +1,18 @@
 require 'guard'
-require 'guard/guard'
 
 module Guard
   # Guard::Reek class, it implements an guard for reek task
-  class Reek < Guard
+  class Reek < Plugin
     SUCCESS = ["Passed", { title: "Passed", image: :success }]
     FAILED = ["Failed", { title: "Failed", image: :failed }]
 
     attr_reader :last_result, :options
 
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @options = { run_all: true }.merge options
       @files = Dir["**/*"]
+      watchers = options[:watchers] || []
       @files.select! do |file|
         watchers.reduce(false) { |res, watcher| res || watcher.match(file) }
       end

--- a/spec/guard/reek_spec.rb
+++ b/spec/guard/reek_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Guard::Reek do
   subject { reek }
-  let(:guard) { described_class.new [], options }
+  let(:guard) { described_class.new options }
   let(:options) { {} }
 
   before do


### PR DESCRIPTION
Upgraded to Guard 2.0 version following the guideline described at https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
